### PR TITLE
fix docker-compose to work with version > .18

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ services:
     environment:
       BITCOIN_EXTRA_ARGS: |
         testnet=1
-        whitelist=0.0.0.0/0
         server=1
+        rpcallowip=0.0.0.0/0
+        rpcbind=127.0.0.1
+        rpcbind=bitcoind
         rpcuser=rpcuser
         rpcpassword=rpcpass
     expose:


### PR DESCRIPTION
Previous version of docker-compose file was giving `Binding RPC on address :: port 18332 failed.`

This issue suggested this fix which works for me. 
https://github.com/bitcoin/bitcoin/issues/16209